### PR TITLE
Remove conversion to gif as it is not supported by ruby-vips.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,8 +21,8 @@ to include the Vips module in the upload class:
 You can use the following methods to resize your images. All methods keep
 aspect ratio:
 
-* resize_to_fill(x,y) Will increase/decrease the size of the image and match the specified dimensions exactly, chopping off any extraneous bits.
-* resize_to_fit(x,y) Will increase/decrease the size of the image to fit within the specified dimensions. One dimension may be less than specified.
-* resize_to_limit(x,y) Just like resize_to_fit except will not increase size of image.
-* format("jpeg|png|gif") Changes the format of the image
-* quality(0-100) Sets the quality of the image being saved if JPEG
+* `resize_to_fill(x,y)` Will increase/decrease the size of the image and match the specified dimensions exactly, chopping off any extraneous bits.
+* `resize_to_fit(x,y)` Will increase/decrease the size of the image to fit within the specified dimensions. One dimension may be less than specified.
+* `resize_to_limit(x,y)` Just like resize_to_fit except will not increase size of image.
+* `format("jpeg|png|gif")` Changes the format of the image
+* `quality(0-100)` Sets the quality of the image being saved if JPEG

--- a/lib/carrierwave/vips.rb
+++ b/lib/carrierwave/vips.rb
@@ -57,12 +57,12 @@ module CarrierWave
     #
     #
     # === Parameters
-    # [f (String)] the format for the file format (jpeg, png, gif)
+    # [f (String)] the format for the file format (jpeg, png)
     # [opts (Hash)] options to be passed to converting function (ie, :interlace => true for png)
     #
     def convert(f, opts = {})
       f = f.to_s.downcase
-      allowed = %w(jpeg png gif)
+      allowed = %w(jpeg png)
       raise ArgumentError, "Format must be one of: #{allowed.join(',')}" unless allowed.include?(f)
       @_format = f
       @_format_opts = opts


### PR DESCRIPTION
ruby-vips does not have a gif converter class anymore (not sure if it did before?) so it will error out when trying to convert to gif.

You can see the available writer classes here: https://github.com/jcupitt/ruby-vips/blob/master/lib/vips/writer.rb#L235-262
