### PR TITLE
Bug fix for `image` being overwritten from VIPS::Image.new(current_path) in #resize_image

### DIFF
--- a/lib/carrierwave/vips.rb
+++ b/lib/carrierwave/vips.rb
@@ -213,11 +213,8 @@ module CarrierWave
       if jpeg? # find the shrink ratio for loading
         shrink_factor = [8, 4, 2, 1].find {|sf| 1.0 / ratio >= sf }
         shrink_factor = 1 if shrink_factor == nil
-        image = VIPS::Image.jpeg current_path, 
-            :shrink_factor => shrink_factor, :sequential => true
+        image = image.shrink(shrink_factor)
         ratio = get_ratio image, width, height, min_or_max
-      elsif png?
-        image = VIPS::Image.png current_path, :sequential => true
       end
       if ratio > 1
         image = image.affinei_resize :nearest, ratio


### PR DESCRIPTION
Previously, when resize_image was called, it would re-read the image from disk (adding the amount of shrink, and setting :sequential to true). This caused previous manipulations to be erased; this was especially problematic when trying to crop a photo using extract_area and then resize it to fill.

This may not be the best fix, but it works. I was unable to find a method to set :sequential to true in ruby-vips; perhaps, I just didnt look hard enough.

Please let me know if you need anything changed, or if I can prepare my commit better.

Best,
Seve
