### PR TITLE
Added supported for image files that contain alphanumerica extensiosn (3...

### DIFF
--- a/lib/carrierwave/vips.rb
+++ b/lib/carrierwave/vips.rb
@@ -190,7 +190,7 @@ module CarrierWave
     def process!(*)
       ret = super
       if @_vimage
-        tmp_name = current_path.sub(/(\.[a-z]+)$/i, '_tmp\1')
+        tmp_name = current_path.sub(/(\.[[:alnum:]]+)$/i, '_tmp\1')
         writer = writer_class.send(:new, @_vimage, @_format_opts)
         if @_strip
           writer.remove_exif


### PR DESCRIPTION
Added supported for image files that contain alphanumerica extensiosn (3FR). When writing a new file in process!, a temp file is created. Previously, this temp file was created by inserting _tmp between the file basename and the extension. The regular expression didn't account for extensions with numeric values. Now it does (I use [[::alnum::]])
