### PR TITLE
Quality method did not work. Now fixed

### DIFF
--- a/lib/carrierwave/vips.rb
+++ b/lib/carrierwave/vips.rb
@@ -51,7 +51,7 @@ module CarrierWave
     #
     def quality(percent)
       manipulate! do |image|
-        image.quality = percent if image.respond_to?(:quality=)
+        @_format_opts = { quality: percent } if jpeg? || @_format=='jpeg'
         image
       end
     end


### PR DESCRIPTION
The quality method was checking if image responded to :quality=, which will always fail. As far as I can see, VIPS::Image contains no quality method (VIPS::JPEGWriter seems to have a quality method, but no quality=). Quality is now set via the writer format options instance variable (@_format_opts). Currently, it assumes that the only format to accept quality is jpeg, checking that either the original file format or conversion format are jpeg before setting the format options variable.
