### PR TITLE
Prevent rmagick installation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'rmagick'
 gem 'carrierwave-datamapper', :require => 'carrierwave/datamapper', git: 'git@github.com:eltiare/carrierwave-datamapper.git'
 gem 'ruby-vips', :require => 'vips'
 

--- a/carrierwave-vips.gemspec
+++ b/carrierwave-vips.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'ruby-vips', '>=0.2.0'
   s.add_runtime_dependency 'carrierwave'
-  s.add_runtime_dependency 'rmagick'
+  s.add_development_dependency 'rmagick'
 
 end


### PR DESCRIPTION
1. It trys to install rmagick in my production environment.
2. There is no need to put "rmagick" in Gemfile since `gemspec` will handle this.