### PR TITLE
To support Ruby 1.8 is unnecessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.3
+  - 2.0
+  - 2.1
+  - 2.2
 script: "bundle exec rspec spec/"
 gemfile:
   - Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rmagick'
-gem 'carrierwave-datamapper', :require => 'carrierwave/datamapper', git: 'git@github.com:eltiare/carrierwave-datamapper.git'
+gem 'carrierwave-datamapper', :require => 'carrierwave/datamapper', :github => 'eltiare/carrierwave-datamapper'
 gem 'ruby-vips', :require => 'vips'
 
 gem 'rspec', '2.14.1'


### PR DESCRIPTION
code consistency as well since there is `:require => 'carrierwave/datamapper'`