### PR TITLE
correct type in extension for jpg

### DIFF
--- a/lib/carrierwave/vips.rb
+++ b/lib/carrierwave/vips.rb
@@ -268,7 +268,7 @@ module CarrierWave
     end
 
     def jpeg?(path = current_path)
-      %w(jgp jpeg).include? ext(path)
+      %w(jpg jpeg).include? ext(path)
     end
 
     def png?(path = current_path)


### PR DESCRIPTION
Just noticed the extension being wrong.