### PR TITLE
Update ruby vips and carrierwave.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'ruby-vips', require: 'vips'
-gem 'carrierwave', git: 'https://github.com/carrierwaveuploader/carrierwave.git'
+gem 'ruby-vips', '~> 2.0.2', require: 'vips'
+gem 'carrierwave', '~> 1.1.0'
 gem 'rspec', '~> 3.5.0'
 gem 'activerecord', '~> 5.0.0'
 gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'ruby-vips', :require => 'vips'
+gem 'ruby-vips', require: 'vips'
 gem 'carrierwave', git: 'https://github.com/carrierwaveuploader/carrierwave.git'
 gem 'rspec', '~> 3.5.0'
 gem 'activerecord', '~> 5.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,9 @@
-GIT
-  remote: https://github.com/carrierwaveuploader/carrierwave.git
-  revision: a94b68cf848d6bd6ea5fbc2ce7d772456e4a5914
-  specs:
-    carrierwave (0.11.0)
-      activemodel (>= 4.0.0)
-      activesupport (>= 4.0.0)
-      mime-types (>= 1.16)
-
 PATH
   remote: .
   specs:
     carrierwave-vips (1.1.3)
-      carrierwave (>= 0.11.0)
-      ruby-vips (~> 1.0, >= 1.0.2)
+      carrierwave (>= 1.1.0)
+      ruby-vips (~> 2.0, >= 2.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -29,18 +20,18 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.1)
+    carrierwave (1.1.0)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
-    glib2 (3.0.9)
-      pkg-config
-    gobject-introspection (3.0.9)
-      glib2 (= 3.0.9)
+    ffi (1.9.18)
     i18n (0.7.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     minitest (5.9.0)
-    pkg-config (1.1.7)
     rmagick (2.16.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -55,8 +46,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    ruby-vips (1.0.2)
-      gobject-introspection (~> 3.0)
+    ruby-vips (2.0.2)
+      ffi (~> 1.9)
     sqlite3 (1.3.11)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -67,12 +58,12 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 5.0.0)
-  carrierwave!
+  carrierwave (~> 1.1.0)
   carrierwave-vips!
   rmagick
   rspec (~> 3.5.0)
-  ruby-vips
+  ruby-vips (~> 2.0.2)
   sqlite3
 
 BUNDLED WITH
-   1.12.5
+   1.15.4

--- a/carrierwave-vips.gemspec
+++ b/carrierwave-vips.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
   s.files       = ["lib/carrierwave-vips.rb", "lib/carrierwave/vips.rb"]
   s.homepage   = 'https://github.com/eltiare/carrierwave-vips'
 
-  s.add_runtime_dependency 'ruby-vips', '~> 1.0', '>= 1.0.2'
-  s.add_runtime_dependency 'carrierwave', '>= 0.11.0'
+  s.add_runtime_dependency 'ruby-vips', '~> 2.0', '>= 2.0.2'
+  s.add_runtime_dependency 'carrierwave', '>= 1.1.0'
   s.add_development_dependency 'rmagick'
 
 end

--- a/lib/carrierwave/vips.rb
+++ b/lib/carrierwave/vips.rb
@@ -68,8 +68,9 @@ module CarrierWave
           else
             raise('Invalid value for Orientation: ' + o.to_s)
         end
-        image.set('exif-Orientation', '')
-        image.set('exif-ifd0-Orientation', '')
+
+        image.set_type GObject::GSTR_TYPE, 'exif-Orientation', ''
+        image.set_type GObject::GSTR_TYPE, 'exif-ifd0-Orientation', ''
       end
     end
 


### PR DESCRIPTION
This updates ruby-vips & carrierwave to the newer versions.
It also has fixes for setting the exif data more explicitly, to be inline with the newer ruby-vips api.
