### PR TITLE
Allow configuration of allowed file formats

### DIFF
--- a/lib/carrierwave/vips.rb
+++ b/lib/carrierwave/vips.rb
@@ -5,9 +5,10 @@ module CarrierWave
 
     def self.configure
       @config ||= begin
-        c = Struct.new(:sharpen_mask, :sharpen_scale).new
+        c = Struct.new(:sharpen_mask, :sharpen_scale, :allowed_formats).new
         c.sharpen_mask = [ [ -1, -1, -1 ], [ -1, 24, -1 ], [ -1, -1, -1 ] ]
         c.sharpen_scale = 16
+        c.allowed_formats = %w(jpeg jpg png)
         c
       end
       @config
@@ -106,7 +107,7 @@ module CarrierWave
     def convert(f, opts = {})
       opts = opts.dup
       f = f.to_s.downcase
-      allowed = %w(jpeg jpg png)
+      allowed = cwv_config.allowed_formats
       raise ArgumentError, "Format must be one of: #{allowed.join(',')}" unless allowed.include?(f)
       self.format_override = f == 'jpeg' ? 'jpg' : f
       opts[:Q] = opts.delete(:quality) if opts.has_key?(:quality)

--- a/spec/carrierwave/vips_spec.rb
+++ b/spec/carrierwave/vips_spec.rb
@@ -61,7 +61,32 @@ describe CarrierWave::Vips do
     it 'throws an error on gif' do
       expect { instance.convert('gif') }.to raise_error(ArgumentError)
     end
-    
+
+    context 'when allowed formats are configured' do
+      around do |example|
+        original_formats = CarrierWave::Vips.configure.allowed_formats
+        example.run
+      ensure
+        CarrierWave::Vips.configure { |c| c.allowed_formats = original_formats }
+      end
+
+      context 'when a file format is allowed' do
+        before { CarrierWave::Vips.configure { |c| c.allowed_formats = %w(webp) } }
+
+        it 'does not raise an error' do
+          expect { instance.convert('webp') }.not_to raise_error
+        end
+      end
+
+      context 'when a file format is not allowed' do
+        before { CarrierWave::Vips.configure { |c| c.allowed_formats = %w(jpg) } }
+
+        it 'blows up' do
+          expect { instance.convert('png') }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
   end
 
   describe '#resize_to_fill' do


### PR DESCRIPTION
Hi there @eltiare!

First, thanks for your super useful gem. We've got an additional use case, which is that we're creating webp versions, which aren't currently allowed in [`CarrierWave::Vips#convert`
](https://github.com/eltiare/carrierwave-vips/blob/master/lib/carrierwave/vips.rb#L109). We've added an additional field to the configuration struct called `allowed_formats`, which allows folks to customize this list as needed.

We've added test coverage to `CarrierWave::Vips#convert` exercising this change.

Do you have any changes or suggestions?
